### PR TITLE
Fix broken action - zscaler_connector.py: URLs could not be submitted…

### DIFF
--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -1034,13 +1034,15 @@ class ZscalerConnector(BaseConnector):
         new_data.extend(data)
         if new_data:
             cat_details["urls"] = new_data
+        ret_val, response = self._make_rest_call_helper(f"/api/v1/urlCategories/{category_id}?action=ADD_TO_LIST", action_result,
+            data={
+                "superCategory": "USER_DEFINED",
+                "configuredName": cat_details.get("configuredName"),
+                "urls": data
+                },
+            method="put"
+        )
 
-        new_parent_data = cat_details.get("dbCategorizedUrls", [])
-        new_parent_data.extend(parent_data)
-        if new_parent_data:
-            cat_details["dbCategorizedUrls"] = new_parent_data
-
-        ret_val, response = self._make_rest_call_helper(f"/api/v1/urlCategories/{category_id}", action_result, data=cat_details, method="put")
         return ret_val, response
 
     def _handle_add_category_url(self, param):


### PR DESCRIPTION
… to ZScaler Custom URL Categories due to missing parameters.

### Bug Fixes
Describe any bugs you've fixed in this app, and how they were fixed

- Action: Add category URL was broken for Custom URL Categories.  
Previously, URLs were added using the dbCategorizedUrls field and a generic PUT request to /api/v1/urlCategories/{category_id}. This approach failed for Custom URL Categories due to missing required parameters and incorrect endpoint usage.
The fix updates the logic to use the urls field and sends a PUT request to /api/v1/urlCategories/{category_id}?action=ADD_TO_LIST, including necessary fields like superCategory and configuredName. This aligns with ZScaler’s API expectations for modifying Custom URL Categories and restores functionality.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in manual_readme_content.md:

No new REST handlers or authentication methods were added.

No changes affecting deployment compatibility.

However, the behavior of the Add Category URL action has changed for Custom URL Categories and should be noted in the manual to reflect the updated API usage and required parameters.

- [x] I have verified that manual documentation has been updated where appropriate

### Other information
This change ensures compatibility with ZScaler’s current API structure for managing Custom URL Categories.

The update improves reliability and prevents silent failures when adding URLs to user-defined categories.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
