### PR TITLE
fix: remediate Zscaler connector findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.6
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Zscaler
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1307,7 +1307,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Activate staged ZIA policy and destination-group changes before reporting success.
 * Preserve destination-group non-editable state when the edit parameter is omitted.
 * Require HTTPS when transmitting sandbox API tokens to the legacy submission endpoint.
+* Cap server-directed rate-limit waits at 60 seconds and reject malformed values.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Escape file hashes before embedding them in custom-view JavaScript.
 * Activate staged ZIA policy and destination-group changes before reporting success.
 * Preserve destination-group non-editable state when the edit parameter is omitted.
+* Require HTTPS when transmitting sandbox API tokens to the legacy submission endpoint.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 * Preserve destination-group non-editable state when the edit parameter is omitted.
 * Require HTTPS when transmitting sandbox API tokens to the legacy submission endpoint.
 * Cap server-directed rate-limit waits at 60 seconds and reject malformed values.
+* Serialize allowlist read-modify-write actions to prevent concurrent update loss.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Refresh development checks for the connector repository.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Validate numeric user and group identifiers and encode all caller-controlled ZIA path segments.
+* Escape file hashes before embedding them in custom-view JavaScript.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Validate numeric user and group identifiers and encode all caller-controlled ZIA path segments.
 * Escape file hashes before embedding them in custom-view JavaScript.
 * Activate staged ZIA policy and destination-group changes before reporting success.
+* Preserve destination-group non-editable state when the edit parameter is omitted.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Refresh development checks for the connector repository.
+* Validate numeric user and group identifiers and encode all caller-controlled ZIA path segments.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Validate numeric user and group identifiers and encode all caller-controlled ZIA path segments.
 * Escape file hashes before embedding them in custom-view JavaScript.
+* Activate staged ZIA policy and destination-group changes before reporting success.

--- a/zscaler.json
+++ b/zscaler.json
@@ -9,7 +9,7 @@
     "product_name": "Zscaler",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "app_version": "3.0.1",
     "utctime_updated": "2025-09-05T16:54:04.402050Z",
     "package_name": "phantom_zscaler",

--- a/zscaler.json
+++ b/zscaler.json
@@ -1142,6 +1142,10 @@
             "verbose": "If a <b>url_category</b> is specified, it will add the IP(s) as a rule to that category. If it is left blank, it will instead add this IP(s) to the global allowlist.",
             "type": "contain",
             "read_only": false,
+            "lock": {
+                "enabled": true,
+                "concurrency": false
+            },
             "undo": "unallow ip",
             "parameters": {
                 "ip": {
@@ -1290,6 +1294,10 @@
             "verbose": "If a <b>url_category</b> is specified, it will add the URL(s) as a rule to that category. If it is left blank, it will instead add the URL(s) to the global allowed list.",
             "type": "contain",
             "read_only": false,
+            "lock": {
+                "enabled": true,
+                "concurrency": false
+            },
             "undo": "unallow url",
             "parameters": {
                 "url": {
@@ -1468,6 +1476,10 @@
             "verbose": "If a <b>url_category</b> is specified, it will remove the IP(s) from that category. If it is left blank, it will instead remove the IP(s) from the global allowlist.",
             "type": "correct",
             "read_only": false,
+            "lock": {
+                "enabled": true,
+                "concurrency": false
+            },
             "undo": "allowlist ip",
             "parameters": {
                 "ip": {
@@ -1616,6 +1628,10 @@
             "verbose": "If a <b>url_category</b> is specified, it will remove the URL(s) from that category. If it is left blank, it will instead remove the URL(s) from the global allowed list.",
             "type": "correct",
             "read_only": false,
+            "lock": {
+                "enabled": true,
+                "concurrency": false
+            },
             "undo": "allow url",
             "parameters": {
                 "url": {

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -1602,6 +1602,8 @@ class ZscalerConnector(BaseConnector):
         self._sandbox_base_url = config.get("sandbox_base_url", None)
         if self._sandbox_base_url:
             self._sandbox_base_url = self._sandbox_base_url.rstrip("/")
+            if not self._sandbox_base_url.lower().startswith("https://"):
+                return self.set_status(phantom.APP_ERROR, "Sandbox Base URL must use HTTPS")
         self._sandbox_api_token = config.get("sandbox_api_token", None)
         self._headers = {}
         self._retry_rest_call = 5

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -337,6 +337,15 @@ class ZscalerConnector(BaseConnector):
         self.debug_print("Test Connectivity Passed.")
         return self.set_status(phantom.APP_SUCCESS)
 
+    def _activate_config(self, action_result):
+        ret_val, _response = self._make_rest_call_helper("/api/v1/status/activate", action_result, method="post")
+        if phantom.is_fail(ret_val):
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                f"The ZIA change was saved but could not be activated and is not yet enforced. {action_result.get_message()}",
+            )
+        return phantom.APP_SUCCESS
+
     def _filter_endpoints(self, action_result, to_add, existing, action, name):
         if action == "REMOVE_FROM_LIST":
             msg = f"{name} contains none of these endpoints"
@@ -376,6 +385,9 @@ class ZscalerConnector(BaseConnector):
         )
         if phantom.is_fail(ret_val) and self._response.status_code != 204:
             return ret_val
+        ret_val = self._activate_config(action_result)
+        if phantom.is_fail(ret_val):
+            return ret_val
         summary = action_result.set_summary({})
         summary["updated"] = filtered_endpoints
         summary["ignored"] = list(set(endpoints) - set(filtered_endpoints))
@@ -409,6 +421,10 @@ class ZscalerConnector(BaseConnector):
 
         data = {"whitelistUrls": to_add_endpoints}
         ret_val, response = self._make_rest_call_helper("/api/v1/security", action_result, data=data, method="put")
+        if phantom.is_fail(ret_val):
+            return ret_val
+
+        ret_val = self._activate_config(action_result)
         if phantom.is_fail(ret_val):
             return ret_val
 
@@ -463,6 +479,9 @@ class ZscalerConnector(BaseConnector):
         ret_val, response = self._make_rest_call_helper(
             "/api/v1/urlCategories/{}".format(self._category["id"]), action_result, data=data, method="put", params=params, timeout=None
         )
+        if phantom.is_fail(ret_val):
+            return ret_val
+        ret_val = self._activate_config(action_result)
         if phantom.is_fail(ret_val):
             return ret_val
         action_result.add_data(response)
@@ -1054,6 +1073,9 @@ class ZscalerConnector(BaseConnector):
         ret_val, response = self._make_rest_call_helper(
             f"/api/v1/urlCategories/{quote(str(category_id), safe='')}", action_result, data=cat_details, method="put"
         )
+        if phantom.is_fail(ret_val):
+            return ret_val, response
+        ret_val = self._activate_config(action_result)
         return ret_val, response
 
     def _handle_add_category_url(self, param):
@@ -1154,6 +1176,9 @@ class ZscalerConnector(BaseConnector):
         ret_val, response = self._make_rest_call_helper(
             f"/api/v1/urlCategories/{quote(str(category_id), safe='')}", action_result, data=cat_details, method="put"
         )
+        if phantom.is_fail(ret_val):
+            return ret_val, response
+        ret_val = self._activate_config(action_result)
         return ret_val, response
 
     def _handle_remove_category_url(self, param):
@@ -1213,6 +1238,9 @@ class ZscalerConnector(BaseConnector):
         ret_val, response = self._make_rest_call_helper("/api/v1/ipDestinationGroups", action_result, data=data, method="post")
         if phantom.is_fail(ret_val):
             return action_result.get_status()
+        ret_val = self._activate_config(action_result)
+        if phantom.is_fail(ret_val):
+            return ret_val
 
         action_result.add_data(response)
         summary = action_result.update_summary({})
@@ -1350,6 +1378,9 @@ class ZscalerConnector(BaseConnector):
         )
         if phantom.is_fail(ret_val):
             return action_result.get_status()
+        ret_val = self._activate_config(action_result)
+        if phantom.is_fail(ret_val):
+            return ret_val
 
         action_result.add_data(response)
         summary = action_result.update_summary({})
@@ -1376,6 +1407,9 @@ class ZscalerConnector(BaseConnector):
             if phantom.is_fail(ret_val):
                 return action_result.get_status()
             action_result.add_data({"ip_group_id": group_id})
+        ret_val = self._activate_config(action_result)
+        if phantom.is_fail(ret_val):
+            return ret_val
 
         summary = action_result.update_summary({})
         summary["message"] = "Destination groups deleted"

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -19,6 +19,7 @@ import ipaddress
 import json
 import re
 import time
+from urllib.parse import quote
 
 import phantom.app as phantom
 import phantom.rules as phantom_rules
@@ -880,8 +881,12 @@ class ZscalerConnector(BaseConnector):
 
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        user_id = param["user_id"]
-        group_id = param["group_id"]
+        ret_val, user_id = self._validate_integer(action_result, param["user_id"], "user_id")
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+        ret_val, group_id = self._validate_integer(action_result, param["group_id"], "group_id")
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
         ret_val, user_response = self._make_rest_call_helper(f"/api/v1/users/{user_id}", action_result)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -915,8 +920,12 @@ class ZscalerConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        user_id = param["user_id"]
-        group_id = param["group_id"]
+        ret_val, user_id = self._validate_integer(action_result, param["user_id"], "user_id")
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+        ret_val, group_id = self._validate_integer(action_result, param["group_id"], "group_id")
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
         ret_val, user_response = self._make_rest_call_helper(f"/api/v1/users/{user_id}", action_result)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -1005,7 +1014,9 @@ class ZscalerConnector(BaseConnector):
     def _handle_update_user(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(dict(param)))
-        user_id = param["user_id"]
+        ret_val, user_id = self._validate_integer(action_result, param["user_id"], "user_id")
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
 
         try:
             data = json.loads(param.get("user", "{}"))
@@ -1024,7 +1035,7 @@ class ZscalerConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def _get_category_details(self, id, action_result):
-        ret_val, response = self._make_rest_call_helper(f"/api/v1/urlCategories/{id}", action_result)
+        ret_val, response = self._make_rest_call_helper(f"/api/v1/urlCategories/{quote(str(id), safe='')}", action_result)
         if phantom.is_fail(ret_val):
             return action_result.get_status(), None
         return phantom.APP_SUCCESS, response
@@ -1040,7 +1051,9 @@ class ZscalerConnector(BaseConnector):
         if new_parent_data:
             cat_details["dbCategorizedUrls"] = new_parent_data
 
-        ret_val, response = self._make_rest_call_helper(f"/api/v1/urlCategories/{category_id}", action_result, data=cat_details, method="put")
+        ret_val, response = self._make_rest_call_helper(
+            f"/api/v1/urlCategories/{quote(str(category_id), safe='')}", action_result, data=cat_details, method="put"
+        )
         return ret_val, response
 
     def _handle_add_category_url(self, param):
@@ -1138,7 +1151,9 @@ class ZscalerConnector(BaseConnector):
         cat_details["urls"] = new_data
         cat_details["dbCategorizedUrls"] = new_parent_data
 
-        ret_val, response = self._make_rest_call_helper(f"/api/v1/urlCategories/{category_id}", action_result, data=cat_details, method="put")
+        ret_val, response = self._make_rest_call_helper(
+            f"/api/v1/urlCategories/{quote(str(category_id), safe='')}", action_result, data=cat_details, method="put"
+        )
         return ret_val, response
 
     def _handle_remove_category_url(self, param):
@@ -1206,7 +1221,7 @@ class ZscalerConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def _get_destination_group(self, id, action_result, exclude_type=None, category_type=None, lite=False):
-        ret_val, response = self._make_rest_call_helper(f"/api/v1/ipDestinationGroups/{id}", action_result)
+        ret_val, response = self._make_rest_call_helper(f"/api/v1/ipDestinationGroups/{quote(str(id), safe='')}", action_result)
         if phantom.is_fail(ret_val):
             return action_result.get_status(), None
 
@@ -1330,7 +1345,9 @@ class ZscalerConnector(BaseConnector):
             group_resp["countries"] = new_countries
         group_resp["isNonEditable"] = param.get("is_non_editable", False)
 
-        ret_val, response = self._make_rest_call_helper(f"/api/v1/ipDestinationGroups/{group_id}", action_result, data=group_resp, method="put")
+        ret_val, response = self._make_rest_call_helper(
+            f"/api/v1/ipDestinationGroups/{quote(str(group_id), safe='')}", action_result, data=group_resp, method="put"
+        )
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
@@ -1353,7 +1370,9 @@ class ZscalerConnector(BaseConnector):
         list_group_ids = [item.strip() for item in group_ids.split(",") if item.strip()]
 
         for group_id in list_group_ids:
-            ret_val, _response = self._make_rest_call_helper(f"/api/v1/ipDestinationGroups/{group_id}", action_result, method="delete")
+            ret_val, _response = self._make_rest_call_helper(
+                f"/api/v1/ipDestinationGroups/{quote(str(group_id), safe='')}", action_result, method="delete"
+            )
             if phantom.is_fail(ret_val):
                 return action_result.get_status()
             action_result.add_data({"ip_group_id": group_id})

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -244,15 +244,20 @@ class ZscalerConnector(BaseConnector):
         return self._process_response(r, action_result)
 
     def _parse_retry_time(self, retry_time):
-        # Instead of just giving a second value, "retry-time" will return a string like "0 seconds"
-        # I don't know if the second unit can be not seconds
-        parts = retry_time.split()
-        if parts[1].lower() == "seconds":
-            return int(parts[0])
-        if parts[1].lower() == "minutes":
-            return int(parts[0]) * 60
-        else:
+        try:
+            parts = str(retry_time).split()
+            if parts[1].lower() == "seconds":
+                seconds = int(parts[0])
+            elif parts[1].lower() == "minutes":
+                seconds = int(parts[0]) * 60
+            else:
+                return None
+        except (IndexError, TypeError, ValueError):
             return None
+
+        if seconds < 0:
+            return None
+        return min(seconds, ZSCALER_MAX_RETRY_WAIT_SECONDS)
 
     def _make_rest_call_helper(self, *args, **kwargs):
         # There are two rate limits

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -1371,7 +1371,7 @@ class ZscalerConnector(BaseConnector):
         if param.get("countries"):
             new_countries = [item.strip() for item in param.get("countries", "").split(",") if item.strip()]
             group_resp["countries"] = new_countries
-        group_resp["isNonEditable"] = param.get("is_non_editable", False)
+        group_resp["isNonEditable"] = param.get("is_non_editable", group_resp.get("isNonEditable", False))
 
         ret_val, response = self._make_rest_call_helper(
             f"/api/v1/ipDestinationGroups/{quote(str(group_id), safe='')}", action_result, data=group_resp, method="put"

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -1,6 +1,6 @@
 # File: zscaler_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -322,7 +322,7 @@ class ZscalerConnector(BaseConnector):
         action_result = ActionResult()
         config = self.get_config()
         self._base_url = config["base_url"].rstrip("/")
-        ret_val, response = self._make_rest_call_helper("/api/v1/authenticatedSession", action_result, method="delete")
+        ret_val, _response = self._make_rest_call_helper("/api/v1/authenticatedSession", action_result, method="delete")
 
         if phantom.is_fail(ret_val):
             self.debug_print("Deleting the authenticated session failed on the ZScaler server.")
@@ -370,7 +370,7 @@ class ZscalerConnector(BaseConnector):
 
         params = {"action": action}
         data = {"blacklistUrls": filtered_endpoints}
-        ret_val, response = self._make_rest_call_helper(
+        ret_val, _response = self._make_rest_call_helper(
             "/api/v1/security/advanced/blacklistUrls", action_result, params=params, data=data, method="post"
         )
         if phantom.is_fail(ret_val) and self._response.status_code != 204:
@@ -632,7 +632,7 @@ class ZscalerConnector(BaseConnector):
 
         try:
             file_id = param["vault_id"]
-            success, msg, file_info = phantom_rules.vault_info(vault_id=file_id)
+            _success, msg, file_info = phantom_rules.vault_info(vault_id=file_id)
             file_info = next(iter(file_info))
         except IndexError:
             return action_result.set_status(phantom.APP_ERROR, "Vault file could not be found with supplied Vault ID")
@@ -1353,7 +1353,7 @@ class ZscalerConnector(BaseConnector):
         list_group_ids = [item.strip() for item in group_ids.split(",") if item.strip()]
 
         for group_id in list_group_ids:
-            ret_val, response = self._make_rest_call_helper(f"/api/v1/ipDestinationGroups/{group_id}", action_result, method="delete")
+            ret_val, _response = self._make_rest_call_helper(f"/api/v1/ipDestinationGroups/{group_id}", action_result, method="delete")
             if phantom.is_fail(ret_val):
                 return action_result.get_status()
             action_result.add_data({"ip_group_id": group_id})

--- a/zscaler_consts.py
+++ b/zscaler_consts.py
@@ -23,6 +23,7 @@ ZSCALER_STATE_FILE_CORRUPT_ERR = (
 )
 ZSCALER_MAX_PAGESIZE = 1000
 ZSCALER_DEFAULT_TIMEOUT = 30
+ZSCALER_MAX_RETRY_WAIT_SECONDS = 60
 
 # Constants relating to "_validate_integer"
 ZSCALER_VALID_INTEGER_MSG = "Please provide a valid integer value in the {param}"

--- a/zscaler_consts.py
+++ b/zscaler_consts.py
@@ -1,6 +1,6 @@
 # File: zscaler_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zscaler_get_admin_users.html
+++ b/zscaler_get_admin_users.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: zscaler_get_admin_users.html
-    Copyright (c) 2017-2025 Splunk Inc.
+    Copyright (c) 2017-2026 Splunk Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/zscaler_submit_file.html
+++ b/zscaler_submit_file.html
@@ -98,7 +98,7 @@
             <td>
               {% if result.data.md5 %}
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['md5'], 'value':'{{ result.data.md5 }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['md5'], 'value':'{{ result.data.md5|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.data.md5 }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/zscaler_submit_file.html
+++ b/zscaler_submit_file.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: zscaler_submit_file.html
-    Copyright (c) 2017-2025 Splunk Inc.
+    Copyright (c) 2017-2026 Splunk Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/zscaler_view.py
+++ b/zscaler_view.py
@@ -1,6 +1,6 @@
 # File: zscaler_view.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- constrain caller-controlled ZIA endpoint identifiers
- escape custom-view JavaScript values
- activate staged ZIA policy and destination-group changes
- preserve destination-group lock state
- require HTTPS for sandbox submissions
- cap server-directed retry waits
- serialize allowlist read-modify-write operations

## Tracking

- PAPP-37976 under ESPM-5228
- PSAAS-30672, PSAAS-30766, PSAAS-31140, PSAAS-31164
- PSAAS-31738, PSAAS-31749, PSAAS-31770
- PSAAS-32059, PSAAS-32377, PSAAS-32409
- Provenance: VULN-93397, VULN-93491, VULN-93865, VULN-93889, VULN-94463, VULN-94474, VULN-94495, VULN-94783, VULN-95100, VULN-95132
- Legacy: FS-1463, FS-1576, FS-1989, FS-2015, FS-2985, FS-2996, FS-3017, FS-3306, FS-3623, FS-3655

## Verification

- `pre-commit run --all-files`
- `python3 -m py_compile zscaler_connector.py zscaler_consts.py`
- `git diff --check`

## Patch review

Flashpoint patches were adapted to current source. The three path-injection reports share one structural endpoint-safety fix, and the two staged-policy reports share one activation fix; each distinct user-visible behavior has one signed commit and one release-note item. The legacy sandbox endpoint requires its token as a query parameter, so this connector change requires HTTPS rather than inventing an unsupported header scheme.

No breaking connector metadata changes are intended.

Written by Codex.