### PR TITLE
PAPP-37951: Document admin → zsapi Base URL change for Public API deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Product Vendor: Zscaler <br>
 Product Name: Zscaler <br>
 Minimum Product Version: 6.2.2
 
+**NOTE:** "Zscaler is deprecating https://admin.<Zscaler Cloud Name> for Public API traffic in September. In the app's asset settings, update the Base URL to https://zsapi.<Zscaler Cloud Name> to ensure the app continues working. Learn more: https://trust.zscaler.com/zscaler.net/posts/29096".
+
 This app implements containment and investigative actions on Zscaler
 
 Below points are considered for providing the **URL Category** parameter value.
@@ -75,7 +77,7 @@ This table lists the configuration variables required to operate Zscaler. These 
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
-**base_url** | required | string | Base URL (e.g. https://admin.zscaler_instance.net) |
+**base_url** | required | string | Base URL (e.g. https://zsapi.zscaler_instance.net) |
 **api_key** | required | password | API Key |
 **username** | required | string | Username |
 **password** | required | password | Password |


### PR DESCRIPTION
### Summary
Zscaler is deprecating `https://admin.<Zscaler Cloud Name>` for Public API 
traffic in September. This PR updates the Zscaler connector app documentation 
to alert users and point them to the new `zsapi` endpoint.

### Changes
- Added a deprecation notice at the top of the app documentation instructing 
  users to update their asset **Base URL** from `admin` to 
  `https://zsapi.<Zscaler Cloud Name>`.
- Updated the asset configuration table to reference `zsapi` instead of `admin` 
  (e.g. `https://zsapi.zscaler_instance.net`).

### Why
The `admin.<cloud>` host will stop serving Public API traffic in September. 
Assets still pointing at it will break; updating the Base URL to `zsapi` keeps 
the app working. A matching note has been added to the Splunkbase app description.

### Reference
- Jira: PAPP-37951
- Zscaler trust post: https://trust.zscaler.com/zscaler.net/posts/29096

### Notes for reviewers
This edits `README.md` directly. If the README is generated from the app's 
`.json` manifest, please flag it and I'll move the change to the source file.