### PR TITLE
fix: preserve Zscaler pagination results

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.7
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.6
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,5 @@
 **Unreleased**
 
 * Refresh development validation tooling. [PSAAS-32647]
+
+* Continue Zscaler directory pagination when a response returns a short page. [PSAAS-32647]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Refresh development validation tooling. [PSAAS-32647]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,5 @@
 * Continue Zscaler directory pagination when a response returns a short page. [PSAAS-32647]
 
 * Normalize URL schemes before applying Zscaler URL list actions. [PSAAS-32634]
+
+* Bound denylist regular-expression filtering to keep Zscaler actions responsive. [PSAAS-33137]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,5 @@
 * Refresh development validation tooling. [PSAAS-32647]
 
 * Continue Zscaler directory pagination when a response returns a short page. [PSAAS-32647]
+
+* Normalize URL schemes before applying Zscaler URL list actions. [PSAAS-32634]

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -803,7 +803,7 @@ class ZscalerConnector(BaseConnector):
                 return action_result.get_status()
             for admin_user in get_admin_users:
                 admin_users.append(admin_user)
-            limit = limit - params["pageSize"]
+            limit = limit - len(get_admin_users)
             if limit <= 0 or len(get_admin_users) == 0:
                 break
             params["page"] += 1
@@ -844,7 +844,7 @@ class ZscalerConnector(BaseConnector):
                 return action_result.get_status()
             for user in get_users:
                 users.append(user)
-            limit = limit - params["pageSize"]
+            limit = limit - len(get_users)
             if limit <= 0 or len(get_users) == 0:
                 break
             params["page"] += 1
@@ -881,7 +881,7 @@ class ZscalerConnector(BaseConnector):
                 return action_result.get_status()
             for group in get_groups:
                 groups.append(group)
-            limit = limit - params["pageSize"]
+            limit = limit - len(get_groups)
             if limit <= 0 or len(get_groups) == 0:
                 break
             params["page"] += 1
@@ -1287,7 +1287,7 @@ class ZscalerConnector(BaseConnector):
                     for key in extensions:
                         group[key] = extensions[key]
                 action_result.add_data(group)
-            limit = limit - params["pageSize"]
+            limit = limit - len(get_groups)
             if limit <= 0 or len(get_groups) == 0:
                 break
             params["page"] += 1

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -759,9 +759,9 @@ class ZscalerConnector(BaseConnector):
         :return: updated list of url
         """
         for i in range(len(endpoints)):
-            if endpoints[i].startswith("http://"):
+            if endpoints[i].lower().startswith("http://"):
                 endpoints[i] = endpoints[i][(len("http://")) :]
-            elif endpoints[i].startswith("https://"):
+            elif endpoints[i].lower().startswith("https://"):
                 endpoints[i] = endpoints[i][(len("https://")) :]
 
         return endpoints

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -18,6 +18,8 @@
 import ipaddress
 import json
 import re
+import subprocess
+import sys
 import time
 from urllib.parse import quote
 
@@ -29,6 +31,42 @@ from phantom.action_result import ActionResult
 from phantom.base_connector import BaseConnector
 
 from zscaler_consts import *
+
+
+def _filter_denylist_by_query(query, blocklist):
+    """Evaluate a denylist query outside the action worker with a fixed timeout."""
+    worker_code = """
+import json
+import re
+import sys
+
+payload = json.load(sys.stdin)
+try:
+    pattern = re.compile(payload["query"])
+    print(json.dumps({"matches": [entry for entry in payload["blocklist"] if pattern.fullmatch(entry)]}))
+except re.error:
+    print(json.dumps({"error": "invalid regular expression"}))
+"""
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", worker_code],
+            capture_output=True,
+            check=True,
+            input=json.dumps({"query": query, "blocklist": blocklist}),
+            text=True,
+            timeout=5,
+        )
+        response = json.loads(completed.stdout)
+    except subprocess.TimeoutExpired:
+        return None, "Regular expression query timed out after 5 seconds."
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        return None, "Unable to evaluate the regular expression query."
+
+    if "error" in response:
+        return None, "Invalid regular expression query."
+    if not isinstance(response.get("matches"), list):
+        return None, "Unable to evaluate the regular expression query."
+    return response["matches"], None
 
 
 class RetVal(tuple):
@@ -1021,15 +1059,21 @@ class ZscalerConnector(BaseConnector):
         summary = action_result.update_summary({})
         summary["message"] = "Denylist retrieved"
 
-        blocklist = response.get("blacklistUrls", [])
-        for blocked in blocklist:
+        blocklist = []
+        for blocked in response.get("blacklistUrls", []):
             is_ip = self._is_ip_address(blocked)
             if filter == "ip" and not is_ip:
                 continue
             if filter == "url" and is_ip:
                 continue
-            if query and not re.fullmatch(query, blocked):
-                continue
+            blocklist.append(blocked)
+
+        if query:
+            blocklist, error_message = _filter_denylist_by_query(query, blocklist)
+            if error_message:
+                return action_result.set_status(phantom.APP_ERROR, error_message)
+
+        for blocked in blocklist:
             action_result.add_data({"url": blocked})
 
         summary["total_denylist_items"] = action_result.get_data_size()


### PR DESCRIPTION
## Summary

- count records returned by Zscaler in the admin-user, user, group, and batched-group pagination loops
- normalize HTTP and HTTPS URL schemes before Zscaler URL list actions submit or match entries
- bound `get denylist` regular-expression evaluation in a subprocess so a costly query cannot pin the action worker
- refresh connector validation hooks

## Tracking

- PAPP-38310 (ESPM-5228)
- PSAAS-32647
- PSAAS-32634 (VULN-95357, FS-4332)
- PSAAS-33137 (VULN-96707, FS-5292)

PSAAS-32519 is intentionally not covered by this PR pending an operator decision on ZIA allowlist and denylist semantics. No allowlist entries are changed.

## Validation

- `/opt/homebrew/bin/python3.13 -m py_compile zscaler_connector.py`
- helper smoke tests for mixed-case schemes, invalid regexes, and a timeout-triggering regex
- `git diff --check`
- full `pre-commit run --all-files`
- hosted pre-commit and compile checks pending after the update

Written by Codex.
