### PR TITLE
fix: use zsapi Base URL for Public API traffic [PAPP-37951]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.bak*
 .DS_Store
+.venv/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Minimum Product Version: 6.2.2
 
 This app implements containment and investigative actions on Zscaler
 
+**NOTE:** Zscaler is deprecating https://admin.<Zscaler Cloud Name> for Public API traffic in September. In the app's asset settings, update the Base URL to https://zsapi.<Zscaler Cloud Name> to ensure the app continues working.
+
 Below points are considered for providing the **URL Category** parameter value.
 
 - Entire URL category string has to be mentioned in block letters
@@ -75,7 +77,7 @@ This table lists the configuration variables required to operate Zscaler. These 
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
-**base_url** | required | string | Base URL (e.g. https://admin.zscaler_instance.net) |
+**base_url** | required | string | Base URL (e.g. https://zsapi.zscaler_instance.net) |
 **api_key** | required | password | API Key |
 **username** | required | string | Username |
 **password** | required | password | Password |

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -1,3 +1,5 @@
+**NOTE:** Zscaler is deprecating https://admin.<Zscaler Cloud Name> for Public API traffic in September. In the app's asset settings, update the Base URL to https://zsapi.<Zscaler Cloud Name> to ensure the app continues working.
+
 Below points are considered for providing the **URL Category** parameter value.
 
 - Entire URL category string has to be mentioned in block letters

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,2 @@
 **Unreleased**
-* Updated documentation to note admin → zsapi Base URL migration for the Public API deprecation [PAPP-37951]
+* Updated documentation with Zscaler's new Public API Base URL guidance, replacing admin.<Zscaler Cloud Name> with zsapi.<Zscaler Cloud Name> ahead of the September deprecation.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Updated documentation to note admin → zsapi Base URL migration for the Public API deprecation [PAPP-37951]

--- a/zscaler.json
+++ b/zscaler.json
@@ -23,7 +23,7 @@
     "app_wizard_version": "1.0.0",
     "configuration": {
         "base_url": {
-            "description": "Base URL (e.g. https://admin.zscaler_instance.net)",
+            "description": "Base URL (e.g. https://zsapi.zscaler_instance.net)",
             "data_type": "string",
             "required": true,
             "order": 0

--- a/zscaler_connector.py
+++ b/zscaler_connector.py
@@ -131,7 +131,7 @@ class ZscalerConnector(BaseConnector):
         err_text = err_text
 
         msg = (
-            "Please check the asset configuration parameters (the base_url should not end with /api/v1 e.g. https://admin.zscaler_instance.net)."
+            "Please check the asset configuration parameters (the base_url should not end with /api/v1 e.g. https://zsapi.zscaler_instance.net)."
         )
 
         if len(err_text) <= 500:


### PR DESCRIPTION
## Summary
Zscaler is deprecating `https://admin.<Zscaler Cloud Name>` for Public API traffic in September. This PR updates the Zscaler connector to point users at the new `zsapi` endpoint and documents the change, so existing assets keep working after the deprecation.

## Changes
- **Documentation** — Added a deprecation notice at the top of the app docs (`manual_readme_content.md`, regenerated into `README.md`) instructing users to update their asset **Base URL** from `admin` to `https://zsapi.<Zscaler Cloud Name>`.
- **Asset config** — Updated the Base URL example in `zscaler.json` from `https://admin.zscaler_instance.net` to `https://zsapi.zscaler_instance.net`.
- **Connector code** — Updated the error/help message in `zscaler_connector.py` (L134) to reference the `zsapi` Base URL example.

## Why
The `admin.<cloud>` host stops serving Public API traffic in September. Assets still pointing at it will break; switching the Base URL to `zsapi` keeps the app functional. A matching note was added to the Splunkbase app description.

## Testing
Verified against a `zscalerbeta` tenant in Splunk SOAR:
- `test connectivity` passes with the `zsapi` Base URL.
- Actions execute successfully with requests going to `https://zsapi.zscalerbeta.net/...` (confirmed in console output).

## Reference
- Jira: PAPP-37951
- Zscaler trust post: https://trust.zscaler.com/zscaler.net/posts/29096